### PR TITLE
Fix API docs URL in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ praxis-network/
 6. **Access the application**
    - Frontend (Web): http://localhost:3000
    - Backend API: http://localhost:3001/api
-   - API Documentation: http://localhost:3001/api-docs
+  - API Documentation: http://localhost:3001/api/docs
 
 ## Running Services
 


### PR DESCRIPTION
## Summary
- correct the Swagger endpoint path in the README

## Testing
- `pnpm install` *(fails: Local package.json exists, but node_modules missing, did you mean to install?)*
- `npm test` *(fails to run tests due to missing database and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_68478ea7c204833197cc10d1afd05947